### PR TITLE
Fixed some building issues 

### DIFF
--- a/BromScript/Managers/Debugger.cpp
+++ b/BromScript/Managers/Debugger.cpp
@@ -120,7 +120,7 @@ namespace BromScript {
 		p.Send();
 
 		p.WriteByte(1);
-		p.WriteInt((int)this->BSI);
+		p.WriteLong((long long)this->BSI);
 		p.Send();
 
 		this->Connected = true;

--- a/BromScript/Objects/ByteReader.h
+++ b/BromScript/Objects/ByteReader.h
@@ -31,11 +31,11 @@ namespace BromScript {
 		Scratch::CString* StringTable;
 		unsigned char* Code;
 
-                inline unsigned char ReadByte() {
+		inline unsigned char ReadByte() {
 			return this->Code[this->Pos++];
 		}
 
-                inline unsigned char* ReadBytes(int len) {
+		inline unsigned char* ReadBytes(int len) {
 			unsigned char* ret = new unsigned char[len];
 			memcpy(ret, this->Code + this->Pos, len);
 			this->Pos += len;
@@ -43,11 +43,11 @@ namespace BromScript {
 			return ret;
 		}
 
-                inline bool ReadBool() {
+		inline bool ReadBool() {
 			return this->Code[this->Pos++] == 1;
 		}
 
-                inline double ReadDouble() {
+		inline double ReadDouble() {
 			double num = 0;
 			memcpy(&num, this->Code + this->Pos, 8);
 			this->Pos += 8;
@@ -55,7 +55,7 @@ namespace BromScript {
 			return num;
 		}
 
-                inline short ReadShort() {
+		inline short ReadShort() {
 			short num = 0;
 			memcpy(&num, this->Code + this->Pos, 2);
 
@@ -63,7 +63,7 @@ namespace BromScript {
 			return num;
 		}
 
-                inline int ReadInt() {
+		inline int ReadInt() {
 			int num = 0;
 			memcpy(&num, this->Code + this->Pos, 4);
 
@@ -71,7 +71,7 @@ namespace BromScript {
 			return num;
 		}
 
-                inline Scratch::CString& ReadString() {
+		inline Scratch::CString& ReadString() {
 			return this->StringTable[this->ReadShort()];
 		}
 

--- a/BromScript/Objects/ByteReader.h
+++ b/BromScript/Objects/ByteReader.h
@@ -31,11 +31,11 @@ namespace BromScript {
 		Scratch::CString* StringTable;
 		unsigned char* Code;
 
-		inline unsigned char ByteReader::ReadByte() {
+                inline unsigned char ReadByte() {
 			return this->Code[this->Pos++];
 		}
 
-		inline unsigned char* ByteReader::ReadBytes(int len) {
+                inline unsigned char* ReadBytes(int len) {
 			unsigned char* ret = new unsigned char[len];
 			memcpy(ret, this->Code + this->Pos, len);
 			this->Pos += len;
@@ -43,11 +43,11 @@ namespace BromScript {
 			return ret;
 		}
 
-		inline bool ByteReader::ReadBool() {
+                inline bool ReadBool() {
 			return this->Code[this->Pos++] == 1;
 		}
 
-		inline double ByteReader::ReadDouble() {
+                inline double ReadDouble() {
 			double num = 0;
 			memcpy(&num, this->Code + this->Pos, 8);
 			this->Pos += 8;
@@ -55,7 +55,7 @@ namespace BromScript {
 			return num;
 		}
 
-		inline short ByteReader::ReadShort() {
+                inline short ReadShort() {
 			short num = 0;
 			memcpy(&num, this->Code + this->Pos, 2);
 
@@ -63,7 +63,7 @@ namespace BromScript {
 			return num;
 		}
 
-		inline int ByteReader::ReadInt() {
+                inline int ReadInt() {
 			int num = 0;
 			memcpy(&num, this->Code + this->Pos, 4);
 
@@ -71,7 +71,7 @@ namespace BromScript {
 			return num;
 		}
 
-		inline Scratch::CString& ByteReader::ReadString() {
+                inline Scratch::CString& ReadString() {
 			return this->StringTable[this->ReadShort()];
 		}
 

--- a/BromScript/Objects/Function.cpp
+++ b/BromScript/Objects/Function.cpp
@@ -242,7 +242,7 @@ namespace BromScript {
 
 			if (this->FixedLocalTypes[i] != -1) {
 				if (var->Type != this->FixedLocalTypes[i]) {
-					BS_THROW_ERROR(this->BromScript, CString::Format("Expected type %s at argument %d, but got %s", Converter::TypeToString(this->BromScript, (VariableType::Enum)this->FixedLocalTypes[i]), i + 1, Converter::TypeToString(this->BromScript, var->Type)).str_szBuffer);
+					BS_THROW_ERROR(this->BromScript, CString::Format("Expected type %s at argument %d, but got %s", (const char*)Converter::TypeToString(this->BromScript, (VariableType::Enum)this->FixedLocalTypes[i]), i + 1, (const char*)Converter::TypeToString(this->BromScript, var->Type)).str_szBuffer);
 					return this->BromScript->GetDefaultVarNull();
 				}
 			}

--- a/BromScript/Scratch/CString.cpp
+++ b/BromScript/Scratch/CString.cpp
@@ -677,11 +677,11 @@ char& CString::operator[](int iIndex) {
 	return this->str_szBuffer[iIndex];
 }
 
-CString operator+(CString &strLHS, const char* szRHS) {
+CString operator+(const CString &strLHS, const char* szRHS) {
 	return CString(strLHS) += szRHS;
 }
 
-CString operator+(CString &strLHS, const char cRHS) {
+CString operator+(const CString &strLHS, const char cRHS) {
 	return CString(strLHS) += cRHS;
 }
 

--- a/BromScript/Scratch/CString.h
+++ b/BromScript/Scratch/CString.h
@@ -95,8 +95,8 @@ public:
 	char& operator[](int iIndex);
 };
 
-CString operator+(CString &strLHS, const char* szRHS);
-CString operator+(CString &strLHS, const char cRHS);
+CString operator+(const CString &strLHS, const char* szRHS);
+CString operator+(const CString &strLHS, const char cRHS);
 
 SCRATCH_NAMESPACE_END;
 #endif // include once check


### PR DESCRIPTION
Fixed some building issues I was having when building with clang 3.6.0.

This is the only error left on my machine (64 bit compiler, so 64 bit pointers), I left it because I'm not sure how you want to solve this on your end.

    BromScript/Managers/Debugger.cpp:123:14: error: cast from pointer to smaller type 'int' loses information
                    p.WriteInt((int)this->BSI);
                               ^~~~~~~~~~~~~~