### PR TITLE
Do not redefine ASSERT if it is already defined

### DIFF
--- a/BromScript/Scratch/Common.h
+++ b/BromScript/Scratch/Common.h
@@ -63,7 +63,9 @@ template<class T> inline T Abs(const T &v) { return v < 0 ? -v : v; }
 }
 #endif
 #else
+#ifndef ASSERT
 #define ASSERT(expr) assert(expr)
+#endif
 #endif
 
 #endif // include once check


### PR DESCRIPTION
To avoid problems with libraries that already define an `ASSERT` macro